### PR TITLE
Implement basic API controllers and routes

### DIFF
--- a/api/app/Http/Controllers/AuthController.php
+++ b/api/app/Http/Controllers/AuthController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class AuthController extends Controller
+{
+    public function register(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|unique:users',
+            'password' => 'required|string|min:6',
+        ]);
+
+        $user = User::create([
+            'name' => $data['name'],
+            'email' => $data['email'],
+            'password' => bcrypt($data['password']),
+        ]);
+
+        return response()->json(['message' => 'User created'], 201);
+    }
+
+    public function login(Request $request)
+    {
+        $credentials = $request->only('email', 'password');
+
+        if (!Auth::attempt($credentials)) {
+            return response()->json(['message' => 'Invalid credentials'], 401);
+        }
+
+        /** @var \App\Models\User $user */
+        $user = $request->user();
+        $token = $user->createToken('api-token')->plainTextToken;
+
+        return response()->json(['token' => $token]);
+    }
+}

--- a/api/app/Http/Controllers/ExamController.php
+++ b/api/app/Http/Controllers/ExamController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class ExamController extends Controller
+{
+    public function index()
+    {
+        return response()->json(['exams' => []]);
+    }
+
+    public function questions($exam)
+    {
+        return response()->json(['questions' => []]);
+    }
+
+    public function submit($exam, Request $request)
+    {
+        return response()->json(['score' => 0]);
+    }
+}

--- a/api/app/Http/Controllers/RankingController.php
+++ b/api/app/Http/Controllers/RankingController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Controllers;
+
+class RankingController extends Controller
+{
+    public function index()
+    {
+        return response()->json(['ranking' => []]);
+    }
+}

--- a/api/app/Http/Controllers/ScoreController.php
+++ b/api/app/Http/Controllers/ScoreController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Controllers;
+
+class ScoreController extends Controller
+{
+    public function index()
+    {
+        return response()->json(['scores' => []]);
+    }
+}

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -1,19 +1,18 @@
 <?php
 
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\AuthController;
+use App\Http\Controllers\ExamController;
+use App\Http\Controllers\ScoreController;
+use App\Http\Controllers\RankingController;
 
-/*
-|--------------------------------------------------------------------------
-| API Routes
-|--------------------------------------------------------------------------
-|
-| Here is where you can register API routes for your application. These
-| routes are loaded by the RouteServiceProvider and all of them will
-| be assigned to the "api" middleware group. Make something great!
-|
-*/
+Route::post('register', [AuthController::class, 'register']);
+Route::post('login', [AuthController::class, 'login']);
 
-Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
-    return $request->user();
+Route::middleware('auth:sanctum')->group(function () {
+    Route::get('exams', [ExamController::class, 'index']);
+    Route::get('exams/{exam}/questions', [ExamController::class, 'questions']);
+    Route::post('exams/{exam}/submit', [ExamController::class, 'submit']);
+    Route::get('scores', [ScoreController::class, 'index']);
+    Route::get('ranking', [RankingController::class, 'index']);
 });


### PR DESCRIPTION
## Summary
- add controllers for authentication, exams, scores, and rankings
- expose new endpoints in `api/routes/api.php`
- stub methods returning JSON data

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68436e80c1cc8325a9d296a0e9129a68