### PR TITLE
Add minimal email-based auth

### DIFF
--- a/api/app/Http/Controllers/AuthController.php
+++ b/api/app/Http/Controllers/AuthController.php
@@ -33,10 +33,6 @@ class AuthController extends Controller
             return response()->json(['message' => 'Invalid credentials'], 401);
         }
 
-        /** @var \App\Models\User $user */
-        $user = $request->user();
-        $token = $user->createToken('api-token')->plainTextToken;
-
-        return response()->json(['token' => $token]);
+        return response()->json(['message' => 'Logged in']);
     }
 }

--- a/api/app/Http/Kernel.php
+++ b/api/app/Http/Kernel.php
@@ -64,5 +64,6 @@ class Kernel extends HttpKernel
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'email.auth' => \App\Http\Middleware\AuthenticateWithEmail::class,
     ];
 }

--- a/api/app/Http/Middleware/AuthenticateWithEmail.php
+++ b/api/app/Http/Middleware/AuthenticateWithEmail.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use App\Models\User;
+
+class AuthenticateWithEmail
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $email = $request->input('email') ?: $request->header('X-User-Email');
+
+        if (!$email || !User::where('email', $email)->exists()) {
+            return response()->json(['message' => 'Unauthenticated'], 401);
+        }
+
+        $user = User::where('email', $email)->first();
+        $request->setUserResolver(fn () => $user);
+
+        return $next($request);
+    }
+}

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -9,7 +9,7 @@ use App\Http\Controllers\RankingController;
 Route::post('register', [AuthController::class, 'register']);
 Route::post('login', [AuthController::class, 'login']);
 
-Route::middleware('auth:sanctum')->group(function () {
+Route::middleware('email.auth')->group(function () {
     Route::get('exams', [ExamController::class, 'index']);
     Route::get('exams/{exam}/questions', [ExamController::class, 'questions']);
     Route::post('exams/{exam}/submit', [ExamController::class, 'submit']);


### PR DESCRIPTION
## Summary
- create `AuthenticateWithEmail` middleware
- register new middleware alias in the kernel
- protect routes with `email.auth`
- simplify login to just return 200 without tokens

## Testing
- `composer install`
- `php artisan key:generate --ansi`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68436fef94488325a8db46c83031ef60