### PR TITLE
Align models with provided SQL schema

### DIFF
--- a/api/app/Models/Answer.php
+++ b/api/app/Models/Answer.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Answer extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'question_id',
+        'contenido',
+        'es_correcta',
+    ];
+
+    protected $casts = [
+        'es_correcta' => 'boolean',
+    ];
+
+    public function question()
+    {
+        return $this->belongsTo(Question::class);
+    }
+}

--- a/api/app/Models/Exam.php
+++ b/api/app/Models/Exam.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Exam extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'titulo',
+        'fecha_inicio',
+        'fecha_fin',
+    ];
+}

--- a/api/app/Models/Question.php
+++ b/api/app/Models/Question.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Question extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'exam_id',
+        'enunciado',
+    ];
+
+    public function exam()
+    {
+        return $this->belongsTo(Exam::class);
+    }
+
+    public function answers()
+    {
+        return $this->hasMany(Answer::class);
+    }
+}

--- a/api/app/Models/Score.php
+++ b/api/app/Models/Score.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Score extends Model
+{
+    use HasFactory;
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'user_id',
+        'exam_id',
+        'puntaje',
+        'created_at',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function exam()
+    {
+        return $this->belongsTo(Exam::class);
+    }
+}

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -18,9 +18,12 @@ class User extends Authenticatable
      * @var array<int, string>
      */
     protected $fillable = [
-        'name',
+        'nombre',
+        'apellido',
         'email',
         'password',
+        'dni',
+        'curso',
     ];
 
     /**
@@ -30,7 +33,6 @@ class User extends Authenticatable
      */
     protected $hidden = [
         'password',
-        'remember_token',
     ];
 
     /**
@@ -39,7 +41,6 @@ class User extends Authenticatable
      * @var array<string, string>
      */
     protected $casts = [
-        'email_verified_at' => 'datetime',
         'password' => 'hashed',
     ];
 }

--- a/api/database/factories/UserFactory.php
+++ b/api/database/factories/UserFactory.php
@@ -4,7 +4,6 @@ namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Str;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
@@ -24,11 +23,12 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->name(),
+            'nombre' => fake()->firstName(),
+            'apellido' => fake()->lastName(),
             'email' => fake()->unique()->safeEmail(),
-            'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
-            'remember_token' => Str::random(10),
+            'dni' => fake()->numerify('########'),
+            'curso' => fake()->word(),
         ];
     }
 
@@ -37,8 +37,6 @@ class UserFactory extends Factory
      */
     public function unverified(): static
     {
-        return $this->state(fn (array $attributes) => [
-            'email_verified_at' => null,
-        ]);
+        return $this;
     }
 }


### PR DESCRIPTION
## Summary
- update `User` model to use Spanish fields
- adjust `UserFactory` to match new user fields
- add models for `Exam`, `Question`, `Answer`, and `Score`

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68437780af788325bd74c1382880e007