### PR TITLE
Simplify API auth via DNI header

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -47,13 +47,6 @@ class AuthController extends Controller
             return response()->json(['message' => 'Invalid credentials'], 401);
         }
 
-        $token = bin2hex(random_bytes(40));
-        $hashed = hash('sha256', $token);
-        DB::insert(
-            'INSERT INTO personal_access_tokens (tokenable_type, tokenable_id, name, token, abilities, created_at, updated_at) VALUES (?, ?, ?, ?, ?, NOW(), NOW())',
-            ['user', $user->id, 'auth_token', $hashed, '["*"]']
-        );
-
-        return response()->json(['token' => $token]);
+        return response()->json(['dni' => $user->dni]);
     }
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -64,6 +64,6 @@ class Kernel extends HttpKernel
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
-        'email.auth' => \App\Http\Middleware\AuthenticateWithEmail::class,
+        'dni.auth' => \App\Http\Middleware\AuthenticateWithDni::class,
     ];
 }

--- a/app/Http/Middleware/AuthenticateWithDni.php
+++ b/app/Http/Middleware/AuthenticateWithDni.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class AuthenticateWithDni
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $dni = $request->header('dni');
+
+        if (!$dni) {
+            return response()->json(['message' => 'Unauthenticated'], 401);
+        }
+
+        $user = DB::selectOne('SELECT * FROM users WHERE dni = ?', [$dni]);
+
+        if (!$user) {
+            return response()->json(['message' => 'Unauthenticated'], 401);
+        }
+
+        $request->setUserResolver(fn () => $user);
+
+        return $next($request);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,7 +9,7 @@ use App\Http\Controllers\RankingController;
 Route::post('register', [AuthController::class, 'register']);
 Route::post('login', [AuthController::class, 'login']);
 
-Route::middleware('email.auth')->group(function () {
+Route::middleware('dni.auth')->group(function () {
     Route::get('exams', [ExamController::class, 'index']);
     Route::get('exams/{exam}/questions', [ExamController::class, 'questions']);
     Route::post('exams/{exam}/submit', [ExamController::class, 'submit']);


### PR DESCRIPTION
## Summary
- add `AuthenticateWithDni` middleware
- use new middleware alias `dni.auth`
- require `dni` header for exam and score routes
- return DNI on login instead of token

## Testing
- `composer install --no-interaction --quiet`
- `php artisan key:generate`
- `vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_687eba986c108325a6efe41bc99971ea